### PR TITLE
use filepath instead of path package

### DIFF
--- a/internal/repository/filesystem.go
+++ b/internal/repository/filesystem.go
@@ -655,7 +655,8 @@ func GetConfigDir() (string, error) {
 		return "", err
 	}
 
-	return filepath.Join(dir, configDir), nil
+	path := filepath.Join(dir, configDir)
+	return path, makeDir(path)
 }
 
 func CreateConfigDir() (string, error) {

--- a/internal/state/requests.go
+++ b/internal/state/requests.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"path"
+	"path/filepath"
 
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/internal/repository"
@@ -158,7 +159,7 @@ func (m *Requests) UpdateCollection(collection *domain.Collection, stateOnly boo
 func fixRequestFilePath(request *domain.Request, collection *domain.Collection) string {
 	collectionDir, _ := path.Split(collection.FilePath)
 	requestFileName := path.Base(request.FilePath)
-	return path.Join(collectionDir, requestFileName)
+	return filepath.Join(collectionDir, requestFileName)
 }
 
 func (m *Requests) GetRequests() []*domain.Request {


### PR DESCRIPTION
Using path package to join directories and names cause issue on windows platform. filepath in other hand handles different os specifications. 

Fixes: #26 