### PR TITLE
Support Copying and selecting response headers and cookies

### DIFF
--- a/internal/domain/app.go
+++ b/internal/domain/app.go
@@ -38,3 +38,11 @@ func CompareKeyValues(a, b []KeyValue) bool {
 
 	return true
 }
+
+func KeyValuesToText(values []KeyValue) string {
+	var text string
+	for _, v := range values {
+		text += v.Key + ": " + v.Value + "\n"
+	}
+	return text
+}

--- a/ui/pages/requests/component/values_table.go
+++ b/ui/pages/requests/component/values_table.go
@@ -71,6 +71,7 @@ func (v *ValuesTable) Layout(gtx layout.Context, theme *chapartheme.Theme) layou
 					l := material.Label(theme.Material(), theme.TextSize, v.Values[i].Key+":")
 					l.Font.Weight = font.Bold
 					l.State = &v.Values[i].keySelectable
+					l.SelectionColor = theme.TextSelectionColor
 					return l.Layout(gtx)
 				})
 			}),
@@ -78,6 +79,7 @@ func (v *ValuesTable) Layout(gtx layout.Context, theme *chapartheme.Theme) layou
 				return layout.Inset{Top: unit.Dp(5)}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 					l := material.Label(theme.Material(), theme.TextSize, v.Values[i].Value)
 					l.State = &v.Values[i].valueSelectable
+					l.SelectionColor = theme.TextSelectionColor
 					return l.Layout(gtx)
 				})
 			}),

--- a/ui/pages/requests/controller.go
+++ b/ui/pages/requests/controller.go
@@ -199,12 +199,12 @@ func (c *Controller) onSubmit(id, containerType string) {
 	}
 }
 
-func (c *Controller) onCopyResponse(gtx layout.Context, response string) {
+func (c *Controller) onCopyResponse(gtx layout.Context, dataType, data string) {
 	gtx.Execute(clipboard.WriteCmd{
-		Data: io.NopCloser(strings.NewReader(response)),
+		Data: io.NopCloser(strings.NewReader(data)),
 	})
 
-	notify.Send("Response copied to clipboard", 2*time.Second)
+	notify.Send(fmt.Sprintf("%s copied to clipboard", dataType), 2*time.Second)
 }
 
 func (c *Controller) onSubmitRequest(id string) {

--- a/ui/pages/requests/restful/response.go
+++ b/ui/pages/requests/restful/response.go
@@ -34,7 +34,7 @@ type Response struct {
 	message  string
 	err      error
 
-	onCopyResponse func(gtx layout.Context, response string)
+	onCopyResponse func(gtx layout.Context, dataType, data string)
 
 	isResponseUpdated   bool
 	responseIsAvailable bool
@@ -65,7 +65,7 @@ func NewResponse(theme *chapartheme.Theme) *Response {
 	return r
 }
 
-func (r *Response) SetOnCopyResponse(f func(gtx layout.Context, response string)) {
+func (r *Response) SetOnCopyResponse(f func(gtx layout.Context, dataType, data string)) {
 	r.onCopyResponse = f
 }
 
@@ -113,7 +113,7 @@ func (r *Response) Layout(gtx layout.Context, theme *chapartheme.Theme) layout.D
 	}
 
 	if r.copyClickable.Clicked(gtx) {
-		r.onCopyResponse(gtx, r.response)
+		r.handleCopy(gtx)
 	}
 
 	inset := layout.Inset{Top: unit.Dp(10)}
@@ -168,4 +168,15 @@ func (r *Response) Layout(gtx layout.Context, theme *chapartheme.Theme) layout.D
 
 func formatStatus(statueCode int, duration time.Duration, size uint64) string {
 	return fmt.Sprintf("%d %s, %s, %s", statueCode, http.StatusText(statueCode), duration, humanize.Bytes(size))
+}
+
+func (r *Response) handleCopy(gtx layout.Context) {
+	switch r.Tabs.Selected() {
+	case 1:
+		r.onCopyResponse(gtx, "Headers", domain.KeyValuesToText(r.responseHeaders.GetData()))
+	case 2:
+		r.onCopyResponse(gtx, "Cookies", domain.KeyValuesToText(r.responseCookies.GetData()))
+	default:
+		r.onCopyResponse(gtx, "Response", r.response)
+	}
 }

--- a/ui/pages/requests/restful/restful.go
+++ b/ui/pages/requests/restful/restful.go
@@ -101,7 +101,7 @@ func (r *Restful) SetOnTitleChanged(f func(title string)) {
 	r.Breadcrumb.SetOnTitleChanged(f)
 }
 
-func (r *Restful) SetOnCopyResponse(f func(gtx layout.Context, response string)) {
+func (r *Restful) SetOnCopyResponse(f func(gtx layout.Context, dataType, data string)) {
 	r.Response.SetOnCopyResponse(f)
 }
 

--- a/ui/pages/requests/view.go
+++ b/ui/pages/requests/view.go
@@ -62,7 +62,7 @@ type View struct {
 	onSave                      func(id string)
 	onSubmit                    func(id, containerType string)
 	onDataChanged               func(id string, data any, containerType string)
-	onCopyResponse              func(gtx layout.Context, response string)
+	onCopyResponse              func(gtx layout.Context, dataType, data string)
 	onOnPostRequestSetChanged   func(id string, statusCode int, item, from, fromKey string)
 	onBinaryFileSelect          func(id string)
 	onFromDataFileSelect        func(requestID, fieldID string)
@@ -172,7 +172,7 @@ func (v *View) RemoveTreeViewNode(id string) {
 	v.treeViewNodes.Delete(id)
 }
 
-func (v *View) SetOnCopyResponse(onCopyResponse func(gtx layout.Context, response string)) {
+func (v *View) SetOnCopyResponse(onCopyResponse func(gtx layout.Context, dataType, data string)) {
 	v.onCopyResponse = onCopyResponse
 }
 
@@ -379,9 +379,9 @@ func (v *View) OpenRequestContainer(req *domain.Request) {
 		}
 	})
 
-	ct.SetOnCopyResponse(func(gtx layout.Context, response string) {
+	ct.SetOnCopyResponse(func(gtx layout.Context, dataType, data string) {
 		if v.onCopyResponse != nil {
-			v.onCopyResponse(gtx, response)
+			v.onCopyResponse(gtx, dataType, data)
 		}
 	})
 


### PR DESCRIPTION
This PR is Adding support to copy the response cookies and headers using Copy button. cookies and headers will be copied as text like flowing example: each key value will b in a new line

`
FOO: Bar
`

It also fixes selection colour of cookies and headers response. 
Know issue to be solved is the fact key and value are using two different state object so is not possible to select them at same time. same issue is exist in json viewer. 

Fixes: #30 