### PR TITLE
chore: fix imports order by using gci

### DIFF
--- a/internal/importer/importer.go
+++ b/internal/importer/importer.go
@@ -6,9 +6,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/google/uuid"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/internal/repository"
-	"github.com/google/uuid"
 )
 
 var variablesMap = map[string]string{

--- a/internal/repository/filesystem.go
+++ b/internal/repository/filesystem.go
@@ -8,8 +8,9 @@ import (
 	"runtime"
 	"strings"
 
-	"github.com/chapar-rest/chapar/internal/domain"
 	"gopkg.in/yaml.v2"
+
+	"github.com/chapar-rest/chapar/internal/domain"
 )
 
 const (

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -4,8 +4,9 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/chapar-rest/chapar/internal/domain"
 	"gopkg.in/yaml.v2"
+
+	"github.com/chapar-rest/chapar/internal/domain"
 )
 
 type Repository interface {

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -13,9 +13,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/internal/state"
-	"github.com/google/uuid"
 )
 
 type Response struct {

--- a/internal/rest/rest_test.go
+++ b/internal/rest/rest_test.go
@@ -3,8 +3,9 @@ package rest
 import (
 	"testing"
 
-	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/google/uuid"
+
+	"github.com/chapar-rest/chapar/internal/domain"
 )
 
 func Test_applyVariables(t *testing.T) {

--- a/main.go
+++ b/main.go
@@ -4,12 +4,12 @@ import (
 	"flag"
 	"log"
 	"net/http"
-	"os"
-
 	_ "net/http/pprof"
+	"os"
 
 	"gioui.org/app"
 	"gioui.org/unit"
+
 	mainApp "github.com/chapar-rest/chapar/ui/app"
 )
 

--- a/ui/app/header.go
+++ b/ui/app/header.go
@@ -5,6 +5,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/internal/state"
 	"github.com/chapar-rest/chapar/ui/chapartheme"

--- a/ui/app/sidebar.go
+++ b/ui/app/sidebar.go
@@ -9,6 +9,7 @@ import (
 	"gioui.org/op/paint"
 	"gioui.org/unit"
 	"gioui.org/widget"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/widgets"
 )

--- a/ui/app/ui.go
+++ b/ui/app/ui.go
@@ -6,8 +6,6 @@ import (
 	"image"
 	"os"
 
-	"github.com/chapar-rest/chapar/ui/pages/workspaces"
-
 	"gioui.org/app"
 	"gioui.org/layout"
 	"gioui.org/op"
@@ -15,6 +13,7 @@ import (
 	"gioui.org/op/paint"
 	"gioui.org/text"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/internal/notify"
 	"github.com/chapar-rest/chapar/internal/repository"
@@ -26,6 +25,7 @@ import (
 	"github.com/chapar-rest/chapar/ui/pages/console"
 	"github.com/chapar-rest/chapar/ui/pages/environments"
 	"github.com/chapar-rest/chapar/ui/pages/requests"
+	"github.com/chapar-rest/chapar/ui/pages/workspaces"
 	"github.com/chapar-rest/chapar/ui/widgets"
 )
 

--- a/ui/pages/console/console.go
+++ b/ui/pages/console/console.go
@@ -8,6 +8,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )

--- a/ui/pages/environments/container.go
+++ b/ui/pages/environments/container.go
@@ -4,6 +4,7 @@ import (
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/converter"

--- a/ui/pages/environments/view.go
+++ b/ui/pages/environments/view.go
@@ -5,6 +5,8 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	giox "gioui.org/x/component"
+	"github.com/google/uuid"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/internal/safemap"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
@@ -12,7 +14,6 @@ import (
 	"github.com/chapar-rest/chapar/ui/keys"
 	"github.com/chapar-rest/chapar/ui/pages/tips"
 	"github.com/chapar-rest/chapar/ui/widgets"
-	"github.com/google/uuid"
 )
 
 const (

--- a/ui/pages/requests/collections/collection.go
+++ b/ui/pages/requests/collections/collection.go
@@ -4,6 +4,7 @@ import (
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/keys"

--- a/ui/pages/requests/component/address_bar.go
+++ b/ui/pages/requests/component/address_bar.go
@@ -7,6 +7,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/widgets"
 )

--- a/ui/pages/requests/component/binary_file.go
+++ b/ui/pages/requests/component/binary_file.go
@@ -4,6 +4,7 @@ import (
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/widgets"
 )

--- a/ui/pages/requests/component/breadcrump.go
+++ b/ui/pages/requests/component/breadcrump.go
@@ -8,6 +8,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/widgets"
 )

--- a/ui/pages/requests/component/form.go
+++ b/ui/pages/requests/component/form.go
@@ -4,6 +4,7 @@ import (
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/keys"
 	"github.com/chapar-rest/chapar/ui/widgets"

--- a/ui/pages/requests/component/form_data.go
+++ b/ui/pages/requests/component/form_data.go
@@ -5,11 +5,12 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+	"github.com/google/uuid"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/keys"
 	"github.com/chapar-rest/chapar/ui/widgets"
-	"github.com/google/uuid"
 )
 
 type FormData struct {

--- a/ui/pages/requests/component/message.go
+++ b/ui/pages/requests/component/message.go
@@ -3,6 +3,7 @@ package component
 import (
 	"gioui.org/layout"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/pages/requests/component/pre_post_request.go
+++ b/ui/pages/requests/component/pre_post_request.go
@@ -7,6 +7,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/keys"

--- a/ui/pages/requests/component/values_table.go
+++ b/ui/pages/requests/component/values_table.go
@@ -8,6 +8,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )

--- a/ui/pages/requests/container.go
+++ b/ui/pages/requests/container.go
@@ -1,11 +1,11 @@
 package requests
 
 import (
+	"gioui.org/layout"
+
+	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/widgets"
-
-	"gioui.org/layout"
-	"github.com/chapar-rest/chapar/internal/domain"
 )
 
 const (

--- a/ui/pages/requests/controller.go
+++ b/ui/pages/requests/controller.go
@@ -9,6 +9,7 @@ import (
 
 	"gioui.org/io/clipboard"
 	"gioui.org/layout"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/internal/importer"
 	"github.com/chapar-rest/chapar/internal/notify"

--- a/ui/pages/requests/restful/auth.go
+++ b/ui/pages/requests/restful/auth.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"gioui.org/layout"
 	"gioui.org/unit"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/pages/requests/component"

--- a/ui/pages/requests/restful/body.go
+++ b/ui/pages/requests/restful/body.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"gioui.org/layout"
 	"gioui.org/unit"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/converter"

--- a/ui/pages/requests/restful/headers.go
+++ b/ui/pages/requests/restful/headers.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"gioui.org/layout"
 	"gioui.org/unit"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/converter"

--- a/ui/pages/requests/restful/params.go
+++ b/ui/pages/requests/restful/params.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"gioui.org/layout"
 	"gioui.org/unit"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/converter"

--- a/ui/pages/requests/restful/request.go
+++ b/ui/pages/requests/restful/request.go
@@ -3,6 +3,7 @@ package restful
 import (
 	"gioui.org/layout"
 	"gioui.org/unit"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/pages/requests/component"

--- a/ui/pages/requests/restful/response.go
+++ b/ui/pages/requests/restful/response.go
@@ -5,16 +5,16 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/chapar-rest/chapar/internal/domain"
-
 	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+	"github.com/dustin/go-humanize"
+
+	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/pages/requests/component"
 	"github.com/chapar-rest/chapar/ui/widgets"
-	"github.com/dustin/go-humanize"
 )
 
 type Response struct {

--- a/ui/pages/requests/restful/restful.go
+++ b/ui/pages/requests/restful/restful.go
@@ -4,6 +4,7 @@ import (
 	"gioui.org/layout"
 	"gioui.org/unit"
 	giox "gioui.org/x/component"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/pages/requests/component"

--- a/ui/pages/requests/view.go
+++ b/ui/pages/requests/view.go
@@ -11,6 +11,8 @@ import (
 	"gioui.org/widget"
 	"gioui.org/x/component"
 	giox "gioui.org/x/component"
+	"github.com/google/uuid"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/internal/safemap"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
@@ -19,7 +21,6 @@ import (
 	"github.com/chapar-rest/chapar/ui/pages/requests/restful"
 	"github.com/chapar-rest/chapar/ui/pages/tips"
 	"github.com/chapar-rest/chapar/ui/widgets"
-	"github.com/google/uuid"
 )
 
 const (

--- a/ui/pages/tips/tips.go
+++ b/ui/pages/tips/tips.go
@@ -8,6 +8,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/assets"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )

--- a/ui/pages/workspaces/view.go
+++ b/ui/pages/workspaces/view.go
@@ -10,6 +10,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/internal/domain"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/widgets"

--- a/ui/widgets/badge_input.go
+++ b/ui/widgets/badge_input.go
@@ -9,6 +9,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/btn.go
+++ b/ui/widgets/btn.go
@@ -6,17 +6,17 @@ import (
 	"math"
 
 	"gioui.org/font"
-	"gioui.org/op"
-	"gioui.org/text"
-	"gioui.org/widget/material"
-	"github.com/chapar-rest/chapar/ui/chapartheme"
-
 	"gioui.org/io/semantic"
 	"gioui.org/layout"
+	"gioui.org/op"
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
+	"gioui.org/text"
 	"gioui.org/unit"
 	"gioui.org/widget"
+	"gioui.org/widget/material"
+
+	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 
 type ButtonStyle struct {

--- a/ui/widgets/code_editor.go
+++ b/ui/widgets/code_editor.go
@@ -12,6 +12,7 @@ import (
 	"gioui.org/widget"
 	"gioui.org/widget/material"
 	"gioui.org/x/richtext"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/chapar-rest/chapar/ui/fonts"
 )

--- a/ui/widgets/dropdown.go
+++ b/ui/widgets/dropdown.go
@@ -9,6 +9,7 @@ import (
 	"gioui.org/widget"
 	"gioui.org/widget/material"
 	"gioui.org/x/component"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/editable_label.go
+++ b/ui/widgets/editable_label.go
@@ -11,6 +11,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/flat_button.go
+++ b/ui/widgets/flat_button.go
@@ -12,6 +12,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/icon_button.go
+++ b/ui/widgets/icon_button.go
@@ -11,6 +11,7 @@ import (
 	"gioui.org/op/paint"
 	"gioui.org/unit"
 	"gioui.org/widget"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/icons.go
+++ b/ui/widgets/icons.go
@@ -4,8 +4,9 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
-	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"golang.org/x/exp/shiny/materialdesign/icons"
+
+	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 
 func MaterialIcons(name string, theme *chapartheme.Theme) material.LabelStyle {

--- a/ui/widgets/jsonviewer.go
+++ b/ui/widgets/jsonviewer.go
@@ -10,6 +10,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/keyvalue.go
+++ b/ui/widgets/keyvalue.go
@@ -9,8 +9,9 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
-	"github.com/chapar-rest/chapar/ui/chapartheme"
 	"github.com/google/uuid"
+
+	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 
 type KeyValue struct {

--- a/ui/widgets/labeled_input.go
+++ b/ui/widgets/labeled_input.go
@@ -5,6 +5,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/notification.go
+++ b/ui/widgets/notification.go
@@ -10,6 +10,7 @@ import (
 	"gioui.org/op/paint"
 	"gioui.org/unit"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/prompt.go
+++ b/ui/widgets/prompt.go
@@ -10,6 +10,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/save_btn.go
+++ b/ui/widgets/save_btn.go
@@ -5,6 +5,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/splitview.go
+++ b/ui/widgets/splitview.go
@@ -8,6 +8,7 @@ import (
 	"gioui.org/op/paint"
 	"gioui.org/unit"
 	"gioui.org/x/component"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/tab.go
+++ b/ui/widgets/tab.go
@@ -5,18 +5,16 @@ import (
 	"image/color"
 	"unicode"
 
+	"gioui.org/layout"
 	"gioui.org/op"
-
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
-
-	"github.com/chapar-rest/chapar/internal/safemap"
-	"github.com/chapar-rest/chapar/ui/chapartheme"
-
-	"gioui.org/layout"
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
+	"github.com/chapar-rest/chapar/internal/safemap"
+	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 
 type Tabs struct {

--- a/ui/widgets/textfield.go
+++ b/ui/widgets/textfield.go
@@ -8,6 +8,7 @@ import (
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
+
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )
 

--- a/ui/widgets/treeview.go
+++ b/ui/widgets/treeview.go
@@ -7,17 +7,17 @@ import (
 	"strings"
 
 	"gioui.org/font"
-	"gioui.org/op"
-
 	"gioui.org/io/input"
 	"gioui.org/io/pointer"
 	"gioui.org/layout"
+	"gioui.org/op"
 	"gioui.org/op/clip"
 	"gioui.org/op/paint"
 	"gioui.org/unit"
 	"gioui.org/widget"
 	"gioui.org/widget/material"
 	"gioui.org/x/component"
+
 	"github.com/chapar-rest/chapar/internal/safemap"
 	"github.com/chapar-rest/chapar/ui/chapartheme"
 )


### PR DESCRIPTION
Usually, import are organized this way:
- imports from standard lib
- space
- imports from public lib (github,golang.org,gitlab,gci...)
- space
- imports from your local code

All imports are sorted alphabetically in each block.

I launched the following command to fix the files

gci write -s standard -s default -s localmodule .

gci can be found here https://github.com/daixiang0/gci/
