### PR TITLE
Feature: Send on Carriage Return

### DIFF
--- a/ui/pages/requests/component/address_bar.go
+++ b/ui/pages/requests/component/address_bar.go
@@ -33,6 +33,7 @@ func NewAddressBar(theme *chapartheme.Theme, address, method string) *AddressBar
 	}
 
 	a.url.SingleLine = true
+	a.url.Submit = true
 	a.url.SetText(address)
 
 	methods := []string{"GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS", "HEAD"}
@@ -88,7 +89,15 @@ func (a *AddressBar) Layout(gtx layout.Context, theme *chapartheme.Theme) layout
 		if !ok {
 			break
 		}
-		if _, ok := event.(widget.ChangeEvent); ok {
+
+		switch event.(type) {
+		// on carriage return event
+		case widget.SubmitEvent:
+			if a.onSubmit != nil {
+				go a.onSubmit()
+			}
+		// on change event
+		case widget.ChangeEvent:
 			if a.onURLChanged != nil {
 				a.onURLChanged(a.url.Text())
 			}

--- a/ui/pages/requests/component/address_bar.go
+++ b/ui/pages/requests/component/address_bar.go
@@ -94,6 +94,7 @@ func (a *AddressBar) Layout(gtx layout.Context, theme *chapartheme.Theme) layout
 		// on carriage return event
 		case widget.SubmitEvent:
 			if a.onSubmit != nil {
+				// goroutine to prevent blocking the ui update
 				go a.onSubmit()
 			}
 		// on change event


### PR DESCRIPTION
# Description

This feature adds the functionality of submitting when the enter key is pressed whilst typing the url. The currenty behaviour of a goui Editor widget is that when SingleLine is set to true, all carriage returns are replaced with spaces. By setting the Submit config value to true we can then handle `SubmitEvent` and `ChangeEvent` with the appropriate event functions.