### PR TITLE
Add GVAL extention to json path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22.1
 require (
 	gioui.org v0.7.1
 	gioui.org/x v0.7.1
+	github.com/PaesslerAG/gval v1.2.2
 	github.com/PaesslerAG/jsonpath v0.1.1
 	github.com/alecthomas/chroma/v2 v2.14.0
 	github.com/dustin/go-humanize v1.0.1
@@ -21,7 +22,6 @@ require (
 	gioui.org/cpu v0.0.0-20220412190645-f1e9e8c3b1f7 // indirect
 	gioui.org/shader v1.0.8 // indirect
 	git.wow.st/gmp/jni v0.0.0-20210610011705-34026c7e22d0 // indirect
-	github.com/PaesslerAG/gval v1.2.2 // indirect
 	github.com/bufbuild/protocompile v0.10.0 // indirect
 	github.com/dlclark/regexp2 v1.11.0 // indirect
 	github.com/go-text/typesetting v0.1.1 // indirect

--- a/internal/jsonpath/jsonpath.go
+++ b/internal/jsonpath/jsonpath.go
@@ -1,18 +1,26 @@
 package jsonpath
 
 import (
+	"context"
 	"encoding/json"
 
+	"github.com/PaesslerAG/gval"
 	"github.com/PaesslerAG/jsonpath"
 )
 
 func Get(input string, path string) (interface{}, error) {
+	builder := gval.Full(jsonpath.PlaceholderExtension())
+	eval, err := builder.NewEvaluable(path)
+	if err != nil {
+		return nil, err
+	}
+
 	v := interface{}(nil)
 	if err := json.Unmarshal([]byte(input), &v); err != nil {
 		return nil, err
 	}
 
-	pathData, err := jsonpath.Get(path, v)
+	pathData, err := eval(context.Background(), v)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR adds support for [GVA (Expression evaluation in golang) ](https://github.com/PaesslerAG/gval) in the JSON Path