### PR TITLE
Show sent headers and metadata in response section

### DIFF
--- a/internal/domain/grpc.go
+++ b/internal/domain/grpc.go
@@ -51,13 +51,14 @@ type GRPCMethod struct {
 }
 
 type GRPCResponseDetail struct {
-	Response   string
-	Metadata   []KeyValue
-	Trailers   []KeyValue
-	StatusCode int
-	Duration   time.Duration
-	Size       int
-	Error      error
+	Response         string
+	RequestMetadata  []KeyValue
+	ResponseMetadata []KeyValue
+	Trailers         []KeyValue
+	StatusCode       int
+	Duration         time.Duration
+	Size             int
+	Error            error
 
 	StatueCode int
 	Status     string

--- a/internal/domain/rest.go
+++ b/internal/domain/rest.go
@@ -381,12 +381,13 @@ func EncodeQueryParams(params []KeyValue) string {
 }
 
 type HTTPResponseDetail struct {
-	Response   string
-	Headers    []KeyValue
-	Cookies    []KeyValue
-	StatusCode int
-	Duration   time.Duration
-	Size       int
+	Response        string
+	ResponseHeaders []KeyValue
+	RequestHeaders  []KeyValue
+	Cookies         []KeyValue
+	StatusCode      int
+	Duration        time.Duration
+	Size            int
 
 	Error error
 }

--- a/internal/egress/requests.go
+++ b/internal/egress/requests.go
@@ -162,7 +162,7 @@ func (s *Service) handlePostRequestFromHeader(r domain.PostRequest, response *re
 		return nil
 	}
 
-	if result, ok := response.Headers[r.PostRequestSet.FromKey]; ok {
+	if result, ok := response.ResponseHeaders[r.PostRequestSet.FromKey]; ok {
 		if env != nil {
 			env.SetKey(r.PostRequestSet.Target, result)
 
@@ -252,7 +252,7 @@ func (s *Service) handlePostRequestFromMetaData(r domain.PostRequest, res *grpc.
 		return nil
 	}
 
-	for _, item := range res.Metadata {
+	for _, item := range res.ResponseMetadata {
 		if item.Key == r.PostRequestSet.FromKey {
 			if env != nil {
 				env.SetKey(r.PostRequestSet.Target, item.Value)

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -19,10 +19,11 @@ import (
 )
 
 type Response struct {
-	StatusCode int
-	Headers    map[string]string
-	Cookies    []*http.Cookie
-	Body       []byte
+	StatusCode      int
+	ResponseHeaders map[string]string
+	RequestHeaders  map[string]string
+	Cookies         []*http.Cookie
+	Body            []byte
 
 	TimePassed time.Duration
 
@@ -164,12 +165,13 @@ func (s *Service) sendRequest(req *domain.HTTPRequestSpec, e *domain.Environment
 
 	// handle response
 	response := &Response{
-		StatusCode: res.StatusCode,
-		Headers:    map[string]string{},
-		Cookies:    res.Cookies(),
-		Body:       body,
-		TimePassed: elapsed,
-		IsJSON:     false,
+		StatusCode:      res.StatusCode,
+		ResponseHeaders: map[string]string{},
+		RequestHeaders:  map[string]string{},
+		Cookies:         res.Cookies(),
+		Body:            body,
+		TimePassed:      elapsed,
+		IsJSON:          false,
 	}
 
 	if IsJSON(string(body)) {
@@ -183,7 +185,11 @@ func (s *Service) sendRequest(req *domain.HTTPRequestSpec, e *domain.Environment
 
 	// handle headers
 	for k, v := range res.Header {
-		response.Headers[k] = strings.Join(v, ", ")
+		response.ResponseHeaders[k] = strings.Join(v, ", ")
+	}
+
+	for k, v := range httpReq.Header {
+		response.RequestHeaders[k] = strings.Join(v, ", ")
 	}
 
 	return response, nil

--- a/ui/app/sidebar.go
+++ b/ui/app/sidebar.go
@@ -29,7 +29,7 @@ type Sidebar struct {
 
 	selectedIndex int
 
-	serviceVersion string
+	appVersion string
 }
 
 type SideBarButton struct {
@@ -37,11 +37,11 @@ type SideBarButton struct {
 	Text string
 }
 
-func NewSidebar(theme *chapartheme.Theme, serviceVersion string) *Sidebar {
+func NewSidebar(theme *chapartheme.Theme, appVersion string) *Sidebar {
 	s := &Sidebar{
-		serviceVersion: serviceVersion,
-		Theme:          theme,
-		cache:          new(op.Ops),
+		appVersion: appVersion,
+		Theme:      theme,
+		cache:      new(op.Ops),
 
 		Buttons: []*SideBarButton{
 			{Icon: widgets.SwapHoriz, Text: "Requests"},
@@ -133,7 +133,7 @@ func (s *Sidebar) Layout(gtx layout.Context, theme *chapartheme.Theme) layout.Di
 									Bottom: unit.Dp(5),
 								}.Layout(gtx, func(gtx layout.Context) layout.Dimensions {
 									gtx.Constraints.Min.X = gtx.Dp(70)
-									st := material.Subtitle1(theme.Theme, s.serviceVersion)
+									st := material.Subtitle1(theme.Theme, s.appVersion)
 									st.Alignment = text.Middle
 									return st.Layout(gtx)
 								})

--- a/ui/app/ui.go
+++ b/ui/app/ui.go
@@ -58,7 +58,7 @@ type UI struct {
 }
 
 // New creates a new UI using the Go Fonts.
-func New(w *app.Window, serviceVersion string) (*UI, error) {
+func New(w *app.Window, appVersion string) (*UI, error) {
 	u := &UI{
 		window: w,
 	}
@@ -100,7 +100,7 @@ func New(w *app.Window, serviceVersion string) (*UI, error) {
 		return nil, err
 	}
 
-	grpcService := grpc.NewService(u.requestsState, u.environmentsState, u.protoFilesState)
+	grpcService := grpc.NewService(appVersion, u.requestsState, u.environmentsState, u.protoFilesState)
 	restService := rest.New(u.requestsState, u.environmentsState)
 
 	egressService := egress.New(u.requestsState, u.environmentsState, restService, grpcService)
@@ -112,7 +112,7 @@ func New(w *app.Window, serviceVersion string) (*UI, error) {
 	u.consolePage = console.New()
 
 	u.header = NewHeader(w, u.environmentsState, u.workspacesState, u.Theme)
-	u.sideBar = NewSidebar(u.Theme, serviceVersion)
+	u.sideBar = NewSidebar(u.Theme, appVersion)
 
 	u.header.LoadWorkspaces(u.workspacesState.GetWorkspaces())
 

--- a/ui/pages/requests/controller.go
+++ b/ui/pages/requests/controller.go
@@ -163,13 +163,14 @@ func (c *Controller) onGrpcInvoke(id string) {
 	}
 
 	c.view.SetGRPCResponse(id, domain.GRPCResponseDetail{
-		Response:   resp.Body,
-		Metadata:   resp.Metadata,
-		Trailers:   resp.Trailers,
-		StatusCode: resp.StatueCode,
-		Duration:   resp.TimePassed,
-		Status:     resp.Status,
-		Size:       resp.Size,
+		Response:         resp.Body,
+		ResponseMetadata: resp.ResponseMetadata,
+		RequestMetadata:  resp.RequestMetadata,
+		Trailers:         resp.Trailers,
+		StatusCode:       resp.StatueCode,
+		Duration:         resp.TimePassed,
+		Status:           resp.Status,
+		Size:             resp.Size,
 	})
 }
 
@@ -236,7 +237,7 @@ func (c *Controller) onPostRequestSetChanged(id string, statusCode int, item, fr
 			return
 		}
 		response = responseData.Response
-		headers = responseData.Headers
+		headers = responseData.ResponseHeaders
 		cookies = responseData.Cookies
 		responseFrom = clone.Spec.HTTP.Request.PostRequest.PostRequestSet.From
 	case domain.RequestTypeGRPC:
@@ -245,8 +246,8 @@ func (c *Controller) onPostRequestSetChanged(id string, statusCode int, item, fr
 			return
 		}
 		response = responseData.Response
-		headers = responseData.Metadata
-		metaData = responseData.Metadata
+		headers = responseData.ResponseMetadata
+		metaData = responseData.ResponseMetadata
 		trailers = responseData.Trailers
 		responseFrom = clone.Spec.GRPC.PostRequest.PostRequestSet.From
 	}
@@ -376,12 +377,13 @@ func (c *Controller) onSubmitRequest(id string) {
 	}
 
 	c.view.SetHTTPResponse(id, domain.HTTPResponseDetail{
-		Response:   resp,
-		Headers:    mapToKeyValue(res.Headers),
-		Cookies:    cookieToKeyValue(res.Cookies),
-		StatusCode: res.StatusCode,
-		Duration:   res.TimePassed,
-		Size:       len(res.Body),
+		Response:        resp,
+		ResponseHeaders: mapToKeyValue(res.ResponseHeaders),
+		RequestHeaders:  mapToKeyValue(res.RequestHeaders),
+		Cookies:         cookieToKeyValue(res.Cookies),
+		StatusCode:      res.StatusCode,
+		Duration:        res.TimePassed,
+		Size:            len(res.Body),
 	})
 }
 

--- a/ui/pages/requests/grpc/grpc.go
+++ b/ui/pages/requests/grpc/grpc.go
@@ -243,7 +243,7 @@ func (r *Grpc) SetRequestBody(body string) {
 
 func (r *Grpc) SetResponse(detail domain.GRPCResponseDetail) {
 	r.Response.SetResponse(detail.Response)
-	r.Response.SetMetadata(detail.Metadata)
+	r.Response.SetMetadata(detail.RequestMetadata, detail.ResponseMetadata)
 	r.Response.SetTrailers(detail.Trailers)
 	r.Response.SetError(detail.Error)
 	r.Response.SetStatusParams(detail.StatusCode, detail.Status, detail.Duration, detail.Size)
@@ -251,9 +251,9 @@ func (r *Grpc) SetResponse(detail domain.GRPCResponseDetail) {
 
 func (r *Grpc) GetResponse() *domain.GRPCResponseDetail {
 	return &domain.GRPCResponseDetail{
-		Response: r.Response.response,
-		Metadata: domain.TextToKeyValue(r.Response.Metadata.Code()),
-		Trailers: domain.TextToKeyValue(r.Response.Trailers.Code()),
+		Response:         r.Response.response,
+		ResponseMetadata: domain.TextToKeyValue(r.Response.Metadata.Code()),
+		Trailers:         domain.TextToKeyValue(r.Response.Trailers.Code()),
 	}
 }
 

--- a/ui/pages/requests/grpc/response.go
+++ b/ui/pages/requests/grpc/response.go
@@ -89,8 +89,24 @@ func (r *Response) SetStatusParams(code int, status string, duration time.Durati
 	r.status = status
 }
 
-func (r *Response) SetMetadata(metadata []domain.KeyValue) {
-	r.Metadata.SetCode(domain.KeyValuesToText(metadata))
+func (r *Response) SetMetadata(requestMetadata, responseMetadata []domain.KeyValue) {
+	if len(requestMetadata) == 0 && len(responseMetadata) == 0 {
+		r.Metadata.SetCode("")
+		return
+	}
+
+	if len(requestMetadata) == 0 {
+		r.Metadata.SetCode(domain.KeyValuesToText(responseMetadata))
+		return
+	}
+
+	if len(responseMetadata) == 0 {
+		r.Metadata.SetCode(domain.KeyValuesToText(requestMetadata))
+		return
+	}
+
+	txt := fmt.Sprintf("# --- Request Metadata ---\n\n%s\n\n# --- Response Metadata ---\n\n%s", domain.KeyValuesToText(requestMetadata), domain.KeyValuesToText(responseMetadata))
+	r.Metadata.SetCode(txt)
 }
 
 func (r *Response) SetTrailers(trailers []domain.KeyValue) {

--- a/ui/pages/requests/restful/response.go
+++ b/ui/pages/requests/restful/response.go
@@ -88,8 +88,23 @@ func (r *Response) SetStatusParams(code int, duration time.Duration, size int) {
 	r.responseSize = size
 }
 
-func (r *Response) SetHeaders(headers []domain.KeyValue) {
-	r.responseHeaders.SetCode(domain.KeyValuesToText(headers))
+func (r *Response) SetHeaders(requestHeaders, responseHeaders []domain.KeyValue) {
+	if len(requestHeaders) == 0 && len(responseHeaders) == 0 {
+		r.responseHeaders.SetCode("")
+	}
+
+	if len(requestHeaders) == 0 {
+		r.responseHeaders.SetCode(domain.KeyValuesToText(responseHeaders))
+		return
+	}
+
+	if len(responseHeaders) == 0 {
+		r.responseHeaders.SetCode(domain.KeyValuesToText(requestHeaders))
+		return
+	}
+
+	txt := fmt.Sprintf("# --- Request Headers ---\n\n%s\n\n# --- Response Headers ---\n\n%s", domain.KeyValuesToText(requestHeaders), domain.KeyValuesToText(responseHeaders))
+	r.responseHeaders.SetCode(txt)
 }
 
 func (r *Response) SetMessage(message string) {

--- a/ui/pages/requests/restful/restful.go
+++ b/ui/pages/requests/restful/restful.go
@@ -128,16 +128,16 @@ func (r *Restful) SetHTTPResponse(detail domain.HTTPResponseDetail) {
 	}
 
 	r.Response.SetResponse(detail.Response)
-	r.Response.SetHeaders(detail.Headers)
+	r.Response.SetHeaders(detail.RequestHeaders, detail.ResponseHeaders)
 	r.Response.SetCookies(detail.Cookies)
 	r.Response.SetStatusParams(detail.StatusCode, detail.Duration, detail.Size)
 }
 
 func (r *Restful) GetHTTPResponse() *domain.HTTPResponseDetail {
 	return &domain.HTTPResponseDetail{
-		Response: r.Response.response,
-		Headers:  domain.TextToKeyValue(r.Response.responseHeaders.Code()),
-		Cookies:  domain.TextToKeyValue(r.Response.responseCookies.Code()),
+		Response:        r.Response.response,
+		ResponseHeaders: domain.TextToKeyValue(r.Response.responseHeaders.Code()),
+		Cookies:         domain.TextToKeyValue(r.Response.responseCookies.Code()),
 	}
 }
 


### PR DESCRIPTION
This Pr is changing the Response section to render the request and response headers/metadata at the same time if available 