### PR TITLE
fix path param parsing issue

### DIFF
--- a/internal/domain/rest_test.go
+++ b/internal/domain/rest_test.go
@@ -1,0 +1,100 @@
+package domain
+
+import "testing"
+
+// TestParsePathParams is the test function for ParsePathParams
+func TestParsePathParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		want   []KeyValue
+	}{
+		{
+			name:   "Single key",
+			params: "/{id}",
+			want: []KeyValue{
+				{Key: "id", Value: "", Enable: true},
+			},
+		},
+		{
+			name:   "Multiple keys",
+			params: "/{user}/{project}/{repo}",
+			want: []KeyValue{
+				{Key: "user", Value: "", Enable: true},
+				{Key: "project", Value: "", Enable: true},
+				{Key: "repo", Value: "", Enable: true},
+			},
+		},
+		{
+			name:   "Nested or invalid keys",
+			params: "/{{project}}/{repo}",
+			want: []KeyValue{
+				{Key: "repo", Value: "", Enable: true},
+			},
+		},
+		{
+			name:   "No keys",
+			params: "/users/projects",
+			want:   []KeyValue{},
+		},
+		{
+			name:   "Empty string",
+			params: "",
+			want:   []KeyValue{},
+		},
+		{
+			name:   "Keys with special characters",
+			params: "/{key1}/{key_2}/{key-3}",
+			want: []KeyValue{
+				{Key: "key1", Value: "", Enable: true},
+				{Key: "key_2", Value: "", Enable: true},
+				{Key: "key-3", Value: "", Enable: true},
+			},
+		},
+		{
+			name:   "Multiple opening braces",
+			params: "/{{id}}/{key}",
+			want: []KeyValue{
+				{Key: "key", Value: "", Enable: true},
+			},
+		},
+		{
+			name:   "Multiple closing braces",
+			params: "/{id}}/{key}",
+			want: []KeyValue{
+				{Key: "id", Value: "", Enable: true},
+				{Key: "key", Value: "", Enable: true},
+			},
+		},
+		{
+			name:   "Keys with invalid nesting",
+			params: "/{user/{project}/{repo}",
+			want: []KeyValue{
+				{Key: "project", Value: "", Enable: true},
+				{Key: "repo", Value: "", Enable: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParsePathParams(tt.params)
+
+			if len(got) != len(tt.want) {
+				t.Errorf("ParsePathParams() length = %v, want %v", len(got), len(tt.want))
+			}
+
+			for i, kv := range got {
+				if kv.Key != tt.want[i].Key {
+					t.Errorf("ParsePathParams()[%d].Key = %v, want %v", i, kv.Key, tt.want[i].Key)
+				}
+				if kv.Value != tt.want[i].Value {
+					t.Errorf("ParsePathParams()[%d].Value = %v, want %v", i, kv.Value, tt.want[i].Value)
+				}
+				if kv.Enable != tt.want[i].Enable {
+					t.Errorf("ParsePathParams()[%d].Enable = %v, want %v", i, kv.Enable, tt.want[i].Enable)
+				}
+			}
+		})
+	}
+}

--- a/ui/pages/requests/controller.go
+++ b/ui/pages/requests/controller.go
@@ -526,6 +526,15 @@ func (c *Controller) checkForHTTPRequestParams(req *domain.Request, inComingRequ
 
 		// update the path params based on the new url
 		newPathParams := domain.ParsePathParams(inComingRequest.Spec.HTTP.URL)
+		// keep the values of the path params that are already set
+		for _, param := range inComingRequest.Spec.HTTP.Request.PathParams {
+			for i, newParam := range newPathParams {
+				if newParam.Key == param.Key {
+					newPathParams[i].Value = param.Value
+				}
+			}
+		}
+
 		c.view.SetPathParams(req.MetaData.ID, newPathParams)
 		inComingRequest.Spec.HTTP.Request.PathParams = newPathParams
 	}


### PR DESCRIPTION
Fixes path parameter parsing by using regex to detect {key} patterns anywhere in the URL (e.g., /user_{id}) and retains existing parameter values when others are removed. Validates against malformed/nested braces (e.g., {h{d}) for robust extraction.