### PR TITLE
fix app crash when scripting is disable

### DIFF
--- a/internal/egress/requests.go
+++ b/internal/egress/requests.go
@@ -10,6 +10,7 @@ import (
 	"github.com/chapar-rest/chapar/internal/grpc"
 	"github.com/chapar-rest/chapar/internal/jsonpath"
 	"github.com/chapar-rest/chapar/internal/logger"
+	"github.com/chapar-rest/chapar/internal/prefs"
 	"github.com/chapar-rest/chapar/internal/rest"
 	"github.com/chapar-rest/chapar/internal/scripting"
 	"github.com/chapar-rest/chapar/internal/state"
@@ -257,7 +258,8 @@ func (s *Service) handleHTTPPostRequest(r domain.PostRequest, request *domain.Re
 		return nil
 	}
 
-	if r.Type == domain.PrePostTypePython {
+	// TODO: this is a temporary solution to fix crashes when scripting is disabled. it need to be improved
+	if r.Type == domain.PrePostTypePython && prefs.GetGlobalConfig().Spec.Scripting.Enabled {
 		return s.handlePostRequestScript(r.Script, request, response, env)
 	}
 

--- a/internal/prefs/prefs.go
+++ b/internal/prefs/prefs.go
@@ -128,6 +128,10 @@ func GetWorkspacePath() string {
 
 // GetGlobalConfig returns a copy of the global config
 func (m *Manager) GetGlobalConfig() domain.GlobalConfig {
+	if m.globalConfig == nil {
+		m.globalConfig = domain.GetDefaultGlobalConfig()
+	}
+
 	return *m.globalConfig
 }
 


### PR DESCRIPTION
Egress package didn't take into account the state of scripting config before trying to run a post request python script. this PR is fixing the issue. a more permanent fix will be in place soon as part of refactoring the egress package.