### PR TITLE
Improve workspace ux tolerance

### DIFF
--- a/ui/app/ui.go
+++ b/ui/app/ui.go
@@ -115,7 +115,13 @@ func New(w *app.Window, appVersion string) (*UI, error) {
 	explorerController := explorer.NewExplorer(w)
 	u.repo = repo
 	u.workspacesView = workspaces.NewView()
-	u.workspacesState = state.NewWorkspaces(repo)
+
+	ws, err := state.NewWorkspaces(repo)
+	if err != nil {
+		return nil, err
+	}
+	u.workspacesState = ws
+
 	u.workspacesController = workspaces.NewController(u.workspacesView, u.workspacesState, repo)
 	if err := u.workspacesController.LoadData(); err != nil {
 		return nil, err

--- a/ui/app/ui.go
+++ b/ui/app/ui.go
@@ -454,7 +454,8 @@ func (u *UI) middleLayout(gtx layout.Context) layout.Dimensions {
 			case 1:
 				return u.environmentsView.Layout(gtx, u.Theme)
 			case 2:
-				return u.workspacesView.Layout(gtx, u.Theme)
+				activeWorkspace := u.workspacesState.GetActiveWorkspace()
+				return u.workspacesView.Layout(gtx, u.Theme, activeWorkspace)
 			case 3:
 				return u.protoFilesView.Layout(gtx, u.Theme)
 			case 4:
@@ -480,7 +481,8 @@ func (u *UI) splitLayout(gtx layout.Context) layout.Dimensions {
 					case 1:
 						return u.environmentsView.Layout(gtx, u.Theme)
 					case 2:
-						return u.workspacesView.Layout(gtx, u.Theme)
+						activeWorkspace := u.workspacesState.GetActiveWorkspace()
+						return u.workspacesView.Layout(gtx, u.Theme, activeWorkspace)
 					case 3:
 						return u.protoFilesView.Layout(gtx, u.Theme)
 					case 4:


### PR DESCRIPTION
This is my first time contributing (ever). I like this project and want to help. Open to feedback.

Workspace existence seems important, and the ux is not very tolerant of it missing. My goal is to ensure one exists.

The lack of a workspace caused a nil deref [here](https://github.com/chapar-rest/chapar/blob/main/ui/app/header.go#L181). This happened to me when first launching chapar, preventing usage. I replicated it with `rm -rf ~/.config/chapar/`. 

To remedy the issue I:
- ensure a workspace is created if none exist on startup
- prevent the user from deleting their active workspace

Notice lack of the delete button on "New Workspace_3"

<img width="993" height="477" alt="Screenshot From 2025-07-12 14-49-51" src="https://github.com/user-attachments/assets/b24f5401-5a8e-4f56-8c37-09da17ab9d2c" />
