### PR TITLE
nil deref in ui/header, no workspaces on disk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+chapar

--- a/internal/state/workspaces.go
+++ b/internal/state/workspaces.go
@@ -122,5 +122,15 @@ func (m *Workspaces) LoadWorkspaces() ([]*domain.Workspace, error) {
 		m.workspaces.Set(w.MetaData.ID, w)
 	}
 
+	if len(m.workspaces.Keys()) < 1 {
+		_default := domain.NewWorkspace("default")
+		err = m.repository.CreateWorkspace(_default)
+		if err != nil {
+			return nil, err
+		}
+
+		ws = append(ws, _default)
+	}
+
 	return ws, nil
 }

--- a/ui/app/header.go
+++ b/ui/app/header.go
@@ -182,7 +182,6 @@ func (h *Header) Layout(gtx layout.Context, theme *chapartheme.Theme) layout.Dim
 	if selectedWorkspace != h.selectedWorkspace {
 		h.selectedWorkspace = selectedWorkspace
 		ws := h.workspacesState.GetWorkspace(selectedWorkspace)
-		// h.workspacesState.SetActiveWorkspace(ws)
 
 		if h.OnSelectedWorkspaceChanged != nil {
 			if err := h.OnSelectedWorkspaceChanged(ws); err != nil {


### PR DESCRIPTION
When calling (*Workspaces).LoadWorkspaces(), it will happily return nothing. This causes a nil deref in ui/app/header @ (*Header).Layout().

Layout() will attempt to retrieve a DropDownOption widgit(selectedWorkspace), j and read its Identifier. When there is no workspaces much less a selected one, we panic.

This change just makes sure that there is at least one called "default"

Cheers,
-Nate