### PR TITLE
feat: add TLS certificate validation toggle to configuration

### DIFF
--- a/internal/domain/config.go
+++ b/internal/domain/config.go
@@ -33,13 +33,14 @@ func (g *GlobalConfig) Changed(other *GlobalConfig) bool {
 }
 
 type GeneralConfig struct {
-	HTTPVersion           string `yaml:"httpVersion"`
-	RequestTimeoutSec     int    `yaml:"timeoutSec"`
-	ResponseSizeMb        int    `yaml:"responseSizeMb"`
-	SendNoCacheHeader     bool   `yaml:"sendNoCacheHeader"`
-	UseHorizontalSplit    bool   `yaml:"useVerticalSplit"`
-	SendChaparAgentHeader bool   `yaml:"sendChaparAgentHeader"`
-	FollowRedirects       bool   `yaml:"followRedirects"`
+	HTTPVersion            string `yaml:"httpVersion"`
+	RequestTimeoutSec      int    `yaml:"timeoutSec"`
+	ResponseSizeMb         int    `yaml:"responseSizeMb"`
+	SendNoCacheHeader      bool   `yaml:"sendNoCacheHeader"`
+	UseHorizontalSplit     bool   `yaml:"useVerticalSplit"`
+	SendChaparAgentHeader  bool   `yaml:"sendChaparAgentHeader"`
+	FollowRedirects        bool   `yaml:"followRedirects"`
+	VaidateTLSCertificates bool   `yaml:"validateTLSCertificates"`
 }
 
 func (g GeneralConfig) Changed(other GeneralConfig) bool {
@@ -49,7 +50,8 @@ func (g GeneralConfig) Changed(other GeneralConfig) bool {
 		g.SendNoCacheHeader != other.SendNoCacheHeader ||
 		g.UseHorizontalSplit != other.UseHorizontalSplit ||
 		g.SendChaparAgentHeader != other.SendChaparAgentHeader ||
-		g.FollowRedirects != other.FollowRedirects
+		g.FollowRedirects != other.FollowRedirects ||
+		g.VaidateTLSCertificates != other.VaidateTLSCertificates
 }
 
 const (
@@ -134,13 +136,14 @@ func GetDefaultGlobalConfig() *GlobalConfig {
 		},
 		Spec: GlobalConfigSpec{
 			General: GeneralConfig{
-				HTTPVersion:           "http/1.1",
-				RequestTimeoutSec:     30,
-				ResponseSizeMb:        10,
-				SendNoCacheHeader:     true,
-				SendChaparAgentHeader: true,
-				UseHorizontalSplit:    true,
-				FollowRedirects:       true,
+				HTTPVersion:            "http/1.1",
+				RequestTimeoutSec:      30,
+				ResponseSizeMb:         10,
+				SendNoCacheHeader:      true,
+				SendChaparAgentHeader:  true,
+				UseHorizontalSplit:     true,
+				FollowRedirects:        true,
+				VaidateTLSCertificates: true,
 			},
 			Editor: EditorConfig{
 				FontFamily:        "JetBrains Mono",
@@ -169,13 +172,14 @@ func GetDefaultGlobalConfig() *GlobalConfig {
 func (g *GlobalConfig) ValuesMap() map[string]any {
 	return map[string]any{
 		"general": map[string]any{
-			"httpVersion":           g.Spec.General.HTTPVersion,
-			"timeoutSec":            g.Spec.General.RequestTimeoutSec,
-			"responseSizeMb":        g.Spec.General.ResponseSizeMb,
-			"sendNoCacheHeader":     g.Spec.General.SendNoCacheHeader,
-			"sendChaparAgentHeader": g.Spec.General.SendChaparAgentHeader,
-			"useHorizontalSplit":    g.Spec.General.UseHorizontalSplit,
-			"followRedirects":       g.Spec.General.FollowRedirects,
+			"httpVersion":            g.Spec.General.HTTPVersion,
+			"timeoutSec":             g.Spec.General.RequestTimeoutSec,
+			"responseSizeMb":         g.Spec.General.ResponseSizeMb,
+			"sendNoCacheHeader":      g.Spec.General.SendNoCacheHeader,
+			"sendChaparAgentHeader":  g.Spec.General.SendChaparAgentHeader,
+			"useHorizontalSplit":     g.Spec.General.UseHorizontalSplit,
+			"followRedirects":        g.Spec.General.FollowRedirects,
+			"validateTLSCertificate": g.Spec.General.VaidateTLSCertificates,
 		},
 		"editor": map[string]any{
 			"fontFamily":        g.Spec.Editor.FontFamily,
@@ -216,6 +220,7 @@ func GlobalConfigFromValues(initial GlobalConfig, values map[string]any) GlobalC
 	g.Spec.General.SendChaparAgentHeader = getOrDefault(values, "sendChaparAgentHeader", g.Spec.General.SendChaparAgentHeader).(bool)
 	g.Spec.General.UseHorizontalSplit = getOrDefault(values, "useHorizontalSplit", g.Spec.General.UseHorizontalSplit).(bool)
 	g.Spec.General.FollowRedirects = getOrDefault(values, "followRedirects", g.Spec.General.FollowRedirects).(bool)
+	g.Spec.General.VaidateTLSCertificates = getOrDefault(values, "validateTLSCertificates", g.Spec.General.VaidateTLSCertificates).(bool)
 
 	g.Spec.Editor.FontFamily = getOrDefault(values, "fontFamily", g.Spec.Editor.FontFamily).(string)
 	g.Spec.Editor.FontSize = getOrDefault(values, "fontSize", g.Spec.Editor.FontSize).(int)

--- a/internal/egress/graphql/graphql.go
+++ b/internal/egress/graphql/graphql.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -158,6 +159,11 @@ func (s *Service) sendRequest(req *domain.GraphQLRequestSpec, e *domain.Environm
 	if !globalConfig.Spec.General.FollowRedirects {
 		client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
+		}
+	}
+	if !globalConfig.Spec.General.VaidateTLSCertificates {
+		client.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 	}
 

--- a/internal/egress/rest/rest.go
+++ b/internal/egress/rest/rest.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"bytes"
+	"crypto/tls"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -164,6 +165,7 @@ func (s *Service) sendRequest(req *domain.HTTPRequestSpec, e *domain.Environment
 		Transport: &http.Transport{
 			MaxIdleConns:           10,
 			MaxResponseHeaderBytes: int64(globalConfig.Spec.General.ResponseSizeMb * 1024 * 1024),
+			TLSClientConfig:        &tls.Config{InsecureSkipVerify: !globalConfig.Spec.General.VaidateTLSCertificates},
 		},
 	}
 	if !globalConfig.Spec.General.FollowRedirects {
@@ -176,6 +178,7 @@ func (s *Service) sendRequest(req *domain.HTTPRequestSpec, e *domain.Environment
 		client.Transport = &http2.Transport{
 			AllowHTTP:        true,
 			MaxReadFrameSize: uint32(globalConfig.Spec.General.ResponseSizeMb * 1024 * 1024),
+			TLSClientConfig:  &tls.Config{InsecureSkipVerify: !globalConfig.Spec.General.VaidateTLSCertificates},
 		}
 	}
 

--- a/ui/pages/settings/view.go
+++ b/ui/pages/settings/view.go
@@ -160,6 +160,7 @@ func (v *View) Load(config domain.GlobalConfig) {
 		widgets.NewNumberItem("Request timeout Seconds", "requestTimeoutSec", "Set how long a request need to wait for the response before timeout, zero means never", config.Spec.General.RequestTimeoutSec),
 		widgets.NewNumberItem("Response Size MB", "responseSizeMb", "Maximum size of the response to download. zero mean unlimited", config.Spec.General.ResponseSizeMb),
 		widgets.NewBoolItem("Follow redirects", "followRedirects", "When enabled, the HTTP client follows 3xx redirects (e.g. 307). When disabled, the first response is returned.", config.Spec.General.FollowRedirects),
+		widgets.NewBoolItem("Validate TLS Certificates", "validateTLSCertificates", "When enabled, the HTTP client validates TLS certificates.", config.Spec.General.VaidateTLSCertificates),
 		widgets.NewHeaderItem("Headers"),
 		widgets.NewBoolItem("Send no-cache header", "sendNoCacheHeader", "Add and send no-cache header in http requests", config.Spec.General.SendNoCacheHeader),
 		widgets.NewBoolItem("Send Chapar agent header", "sendChaparAgentHeader", "Add and send Chapar agent header in http requests", config.Spec.General.SendChaparAgentHeader),


### PR DESCRIPTION
This MR introduces a configuration option to enable or disable TLS certificate validation for outgoing HTTP requests.

**Behavior**
- When validateTLSCertificates = true
  - TLS certificates are validated (secure default)
- When validateTLSCertificates = false
  -  TLS verification is skipped (InsecureSkipVerify = true)